### PR TITLE
Remove robots meta tag in index website

### DIFF
--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -14,7 +14,6 @@ export default function Home(): DetailedHTMLProps<
 		<>
 			<Head>
 				<meta name="description" content={description} />
-				<meta name="robots" content="none" />
 				<meta name="og:title" property="og:title" content={title} />
 				<meta
 					name="og:image"


### PR DESCRIPTION
This will set "robots" to its default: index. Which will tell search engines to index the homepage